### PR TITLE
Add drone task which publishes service sources on successful builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,6 +13,41 @@ steps:
     registry: registry:5000
     insecure: true
 
+- name: publish-service-sources
+  image: alpine/git
+  environment:
+    SSH_KEY:
+      from_secret: github_bot_ssh_key
+  commands:
+    # write the ssh key to disk
+    - mkdir /root/.ssh
+    - echo -n "$SSH_KEY" > /root/.ssh/id_rsa
+    - chmod 600 /root/.ssh/id_rsa
+
+    # add github to known hosts
+    - touch /root/.ssh/known_hosts
+    - chmod 600 /root/.ssh/known_hosts
+    - ssh-keyscan -H github.com > /etc/ssh/ssh_known_hosts 2> /dev/null
+
+    # push service changes
+    - git clone git@github.com:enowars/enowars4-vulnbox-services.git
+    - cd enowars4-vulnbox-services
+    - rm -rf gamemaster/
+    - cp -r ../service/ gamemaster/
+    - git add gamemaster/
+    - git commit -m 'Update gamemaster service'
+    - git push origin HEAD:master
+
+    # push checker changes
+    - cd -
+    - git clone git@github.com:enowars/enowars4-vulnbox-checkers.git
+    - cd enowars4-vulnbox-checkers
+    - rm -rf gamemaster/
+    - cp -r ../checker/ gamemaster/
+    - git add gamemaster/
+    - git commit -m 'Update gamemaster checker'
+    - git push origin HEAD:master
+
 - name: trigger-vm-image-creation
   image: plugins/downstream
   settings:


### PR DESCRIPTION
In order to publish the sources of all services on the vulnbox we bundle
those in an additional repo. The same applies for the checker.

Please note that this requires a service/ and checker/ dir at the project root
as described in https://pad.eno.host/CTFOrganisation#TODO