### PR TITLE
Reuse centrally maintained script for publishing checker & service sources

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,40 +14,15 @@ steps:
     insecure: true
 
 - name: publish-service-sources
-  image: alpine/git
+  image: alpine
   environment:
     SSH_KEY:
       from_secret: github_bot_ssh_key
+    ACCESS_TOKEN:
+      from_secret: github_bot_access_token
   commands:
-    # write the ssh key to disk
-    - mkdir /root/.ssh
-    - echo -n "$SSH_KEY" > /root/.ssh/id_rsa
-    - chmod 600 /root/.ssh/id_rsa
-
-    # add github to known hosts
-    - touch /root/.ssh/known_hosts
-    - chmod 600 /root/.ssh/known_hosts
-    - ssh-keyscan -H github.com > /etc/ssh/ssh_known_hosts 2> /dev/null
-
-    # push service changes
-    - git clone git@github.com:enowars/enowars4-vulnbox-services.git
-    - cd enowars4-vulnbox-services
-    - rm -rf gamemaster/
-    - cp -r ../service/ gamemaster/
-    #- git add gamemaster/
-    - git add -f gamemaster/
-    - git commit -m 'Update gamemaster service' || true
-    - git push origin HEAD:master || true
-
-    # push checker changes
-    - cd -
-    - git clone git@github.com:enowars/enowars4-vulnbox-checkers.git
-    - cd enowars4-vulnbox-checkers
-    - rm -rf gamemaster/
-    - cp -r ../checker/ gamemaster/
-    - git add gamemaster/
-    - git commit -m 'Update gamemaster checker' || true
-    - git push origin HEAD:master || true
+    - apk update && apk add curl bash
+    - curl -s https://$${ACCESS_TOKEN}@raw.githubusercontent.com/enowars/Enowars4DevOps/master/drone-opennebula/push-services.sh | bash -s gamemaster
 
 - name: trigger-vm-image-creation
   image: plugins/downstream


### PR DESCRIPTION
Script will:
* add a docker-compose.override.yml file with external MongoDB config and dummy service replacement for local MongoDB
* overwrite git history for enowars4-vulnbox-{checkers,services} repo
* remove git user information from commit (planned)